### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Kozmic CI
 =========
 
-Documentation is available on [Read the Docs](http://kozmic-ci.readthedocs.org/en/latest/index.html).
+Documentation is available on [Read the Docs](https://kozmic-ci.readthedocs.io/en/latest/index.html).

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -64,4 +64,4 @@ Compiling the documentation
     cd docs
     KOZMIC_CONFIG=kozmic.config_local.DevelopmentConfig make html
 
-.. _Alembic: http://alembic.readthedocs.org/en/latest/index.html
+.. _Alembic: https://alembic.readthedocs.io/en/latest/index.html

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -112,7 +112,7 @@ they must be served through HTTPS to prevent GitHub from caching them
 .. _Digital Ocean: https://www.digitalocean.com/?refcode=429df247edf9
 .. _Docker within Docker: http://blog.docker.io/2013/09/docker-can-now-run-within-docker/
 .. _Supervisor: http://supervisord.org/
-.. _uWSGI: http://uwsgi-docs.readthedocs.org/en/latest/
+.. _uWSGI: https://uwsgi-docs.readthedocs.io/en/latest/
 .. _Kozmic CI's Dockerfile: https://github.com/aromanovich/kozmic-ci/tree/master/docker/Dockerfile
 .. _supervisor.conf: https://github.com/aromanovich/kozmic-ci/blob/master/docker/files/supervisor.conf
 .. _kozmic-uwsgi.ini: https://github.com/aromanovich/kozmic-ci/blob/master/docker/files/kozmic-uwsgi.ini

--- a/kozmic/templates/_base.html
+++ b/kozmic/templates/_base.html
@@ -20,7 +20,7 @@
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
               <li><a href="{{ url_for('repos.index') }}">New Project</a></li>
-              <li><a href="http://kozmic-ci.readthedocs.org/en/{{ get_version() }}/">Docs</a></li>
+              <li><a href="https://kozmic-ci.readthedocs.io/en/{{ get_version() }}/">Docs</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle  username" data-toggle="dropdown">
                   <img src="{{ current_user.gh_avatar_url }}" class="img-circle">

--- a/kozmic/templates/projects/_hook_form.html
+++ b/kozmic/templates/projects/_hook_form.html
@@ -39,7 +39,7 @@
             a shebang directive at the beginning.
           </p>
           <p class="help-block">
-            See <a href="http://kozmic-ci.readthedocs.org/en/latest/reference.html">the documentation</a>
+            See <a href="https://kozmic-ci.readthedocs.io/en/latest/reference.html">the documentation</a>
             about hook configuration.
           </p>
         {% endif %}


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
